### PR TITLE
Bug fix

### DIFF
--- a/version.go
+++ b/version.go
@@ -185,6 +185,13 @@ func compare(v1, v2 string) int {
 	numbers1, strings1 := extract(v1)
 	numbers2, strings2 := extract(v2)
 
+	if len(v1) > 0 && unicode.IsDigit(rune(v1[0])) {
+		strings1 = append([]string{""}, strings1...)
+	}
+	if len(v2) > 0 && unicode.IsDigit(rune(v2[0])) {
+		strings2 = append([]string{""}, strings2...)
+	}
+
 	for i := 0; ; i++ {
 		// Compare non-digit strings
 		diff := compareString(strings1.get(i), strings2.get(i))

--- a/version_test.go
+++ b/version_test.go
@@ -140,6 +140,16 @@ func TestLessThan(t *testing.T) {
 			true,
 		},
 		{
+			Version{upstreamVersion: "1.9.1", debianRevision: "2"},
+			Version{upstreamVersion: "1.16", debianRevision: "1+deb8u1"},
+			true,
+		},
+		{
+			Version{upstreamVersion: "1.9", debianRevision: "2"},
+			Version{upstreamVersion: "1.9.1", debianRevision: "1+deb8u1"},
+			true,
+		},
+		{
 			Version{upstreamVersion: "7.4.052"},
 			Version{epoch: 2, upstreamVersion: "7.4.052"},
 			true,


### PR DESCRIPTION
Wrong
```
v1 = 1.9.1-2
v2 = 1.16-1+deb8u1

v1.LessThan(v2) # => false
```

Correct
```
v1 = 1.9.1-2
v2 = 1.16-1+deb8u1

v1.LessThan(v2) # => true
```

Fix